### PR TITLE
Fixed typo, added new latest firmware for Zoe LBC and LBC2 (0651), reported by HO

### DIFF
--- a/app/src/main/java/lu/fisch/canze/FirmwareActivity.java
+++ b/app/src/main/java/lu/fisch/canze/FirmwareActivity.java
@@ -17,10 +17,10 @@ import lu.fisch.canze.interfaces.FieldListener;
 
 public class FirmwareActivity extends CanzeActivity implements FieldListener {
 
-    private static final int [] zoeVersions     = {0x0203, 0x0112, 0x0650, 0x0a06, 0x0470, 0xc630, 0x0507, 0x014a, 0x1178, 0x1516, 0x140e, 0x0701,      0,      0, 0x0650,      0};
+    private static final int [] zoeVersions     = {0x0203, 0x0112, 0x0651, 0x0a06, 0x0470, 0xc630, 0x0507, 0x014a, 0x1178, 0x1516, 0x140e, 0x0701,      0,      0, 0x0651,      0};
     private static final int [] fluenceVersions = {     1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1};
     private static final int [] kangooVersions  = {     1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1,      1};
-    private static final int [] x10Versions     = {0x0203, 0x0112, 0x0650, 0x0a06, 0x0470, 0xc630, 0x0507, 0x014a, 0x1178, 0x1516, 0x140e, 0x0701,      0,      0, 0x0650,      0};
+    private static final int [] x10Versions     = {0x0203, 0x0112, 0x0651, 0x0a06, 0x0470, 0xc630, 0x0507, 0x014a, 0x1178, 0x1516, 0x140e, 0x0701,      0,      0, 0x0651,      0};
 
     private static int versions [] = null;
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="label_ecu_lbc">LBC (Lithium Battery Charger)</string>
     <string name="lavel_ecu_peb">PEB (Power Electronics Block)</string>
     <string name="label_ecu_aibag">AIBAG (Airbag)</string>
-    <string name="label_ecu_usm">USM (12V fuse box under the hood</string>
+    <string name="label_ecu_usm">USM (12V fuse box under the hood)</string>
     <string name="label_ecu_cluster">CLUSTER (Instrument panel)</string>
     <string name="label_ecu_eps">EPS (Electrical Power Steering)</string>
     <string name="label_ecu_abs">ABS (Antilock breaking system)</string>


### PR DESCRIPTION
Fixed typo, added new latest firmware for Zoe LBC and LBC2 (0651), reported by HO
