### PR TITLE
Cleaned up driving UI (removed useless header above speed, added a triple dot menu for consistancy, fired up the numerical keyboard immediately when activating the distToDest popup.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.4" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="1.7" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/CMCanZE.iml" filepath="$PROJECT_DIR$/CMCanZE.iml" />
       <module fileurl="file://$PROJECT_DIR$/CanZE.iml" filepath="$PROJECT_DIR$/CanZE.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>

--- a/app/src/main/java/lu/fisch/canze/activities/DrivingActivity.java
+++ b/app/src/main/java/lu/fisch/canze/activities/DrivingActivity.java
@@ -10,6 +10,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 //import android.widget.ProgressBar;
 import android.view.View;
+import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -56,51 +58,7 @@ public class DrivingActivity extends CanzeActivity implements FieldListener {
         distkmToDest.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // don't react if we do not have a live odo yet
-                if (odo == 0) return;
-                final Context context = DrivingActivity.this;
-                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
-                LayoutInflater inflater = getLayoutInflater();
-                final View distToDestView = inflater.inflate(R.layout.set_dist_to_dest, null);
-
-                // set dialog message
-                alertDialogBuilder
-                        .setView(distToDestView)
-                        .setTitle("REMAINING DISTANCE")
-                        .setMessage("Please enter the distance to your destination. The display will estimate " +
-                                "the remaining driving distance available in your battery on arrival")
-
-                        .setCancelable(true)
-                        .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                EditText dialogDistToDest = (EditText) distToDestView.findViewById(R.id.dialog_dist_to_dest);
-                                if (dialogDistToDest != null) {
-                                    saveDestOdo(odo + Integer.parseInt(dialogDistToDest.getText().toString()));
-                                }
-                                dialog.cancel();
-                            }
-                        })
-                        .setNeutralButton("Double", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                EditText dialogDistToDest = (EditText) distToDestView.findViewById(R.id.dialog_dist_to_dest);
-                                if (dialogDistToDest != null) {
-                                    saveDestOdo(odo + 2 * Integer.parseInt(dialogDistToDest.getText().toString()));
-                                }
-                                dialog.cancel();
-                            }
-                        })
-                        .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.cancel();
-                            }
-                        });
-
-                // create alert dialog
-                AlertDialog alertDialog = alertDialogBuilder.create();
-
-                // show it
-                alertDialog.show();
-
+                setDistanceToDestination();
             }
         });
 
@@ -114,6 +72,60 @@ public class DrivingActivity extends CanzeActivity implements FieldListener {
         initListeners();
 
     }
+
+    void setDistanceToDestination () {
+        // don't react if we do not have a live odo yet
+        if (odo == 0) return;
+        final Context context = DrivingActivity.this;
+        final EditText textEdit = new EditText(this);
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
+        LayoutInflater inflater = getLayoutInflater();
+        final View distToDestView = inflater.inflate(R.layout.set_dist_to_dest, null);
+
+        // set dialog message
+        alertDialogBuilder
+                .setView(distToDestView)
+                .setTitle("REMAINING DISTANCE")
+                .setMessage("Please enter the distance to your destination. The display will estimate " +
+                        "the remaining driving distance available in your battery on arrival")
+
+                .setCancelable(true)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        EditText dialogDistToDest = (EditText) distToDestView.findViewById(R.id.dialog_dist_to_dest);
+                        if (dialogDistToDest != null) {
+                            saveDestOdo(odo + Integer.parseInt(dialogDistToDest.getText().toString()));
+                        }
+                        dialog.cancel();
+                    }
+                })
+                .setNeutralButton("Double", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        EditText dialogDistToDest = (EditText) distToDestView.findViewById(R.id.dialog_dist_to_dest);
+                        if (dialogDistToDest != null) {
+                            saveDestOdo(odo + 2 * Integer.parseInt(dialogDistToDest.getText().toString()));
+                        }
+                        dialog.cancel();
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.cancel();
+                    }
+                });
+
+        // create alert dialog
+        AlertDialog alertDialog = alertDialogBuilder.create();
+
+        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.toggleSoftInput(InputMethodManager.SHOW_FORCED,0);
+
+        // show it
+        alertDialog.show();
+    }
+
+
+
 
     private void saveDestOdo (int d) {
         SharedPreferences settings = getSharedPreferences(MainActivity.PREFERENCES_FILE, 0);
@@ -304,7 +316,7 @@ public class DrivingActivity extends CanzeActivity implements FieldListener {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_text, menu);
+        getMenuInflater().inflate(R.menu.menu_driving, menu);
         return true;
     }
 
@@ -316,7 +328,8 @@ public class DrivingActivity extends CanzeActivity implements FieldListener {
         int id = item.getItemId();
 
         //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
+        if (id == R.id.action_setDistanceToDestination) {
+            setDistanceToDestination();
             return true;
         }
 

--- a/app/src/main/res/layout/activity_driving.xml
+++ b/app/src/main/res/layout/activity_driving.xml
@@ -53,7 +53,7 @@
             android:max="100"
             android:progressDrawable="@drawable/progressbar_canze"
             />
-
+<!--
         <TextView
             android:id="@+id/HeaderDriving"
             android:layout_width="fill_parent"
@@ -62,7 +62,7 @@
             android:textColor="#000"
             android:layout_marginTop="10dp"
             />
-
+-->
         <TableLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/menu/menu_driving.xml
+++ b/app/src/main/res/menu/menu_driving.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".ElmTestActivity"
+    >
+
+    <item
+        android:id="@+id/action_setDistanceToDestination"
+        android:orderInCategory="100"
+        android:title="Distance to destination"
+        android:visible="true"
+        />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
 
     <string name="default_consumption">#Con</string>
 
-    <string name="label_DistToDest">Dist. to destination</string>
+    <string name="label_DistToDest">Distance to destination</string>
     <string name="default_DistToDest">#ktd</string>
 
     <string name="label_DistAvailAtDest">Dist. available at dest.</string>
@@ -163,7 +163,7 @@
     <string name="label_ecu_bcm">BCM (Body Control Module)</string>
     <string name="label_ecu_clim">CLIM (Climate Control)</string>
     <string name="label_ecu_upa">UPA (Park Assist)</string>
-    <string name="label_ecu_bcb">BCB (?)</string>
+    <string name="label_ecu_bcb">BCB (? Connection Box)</string>
     <string name="label_ecu_lbc2">LBC2 (Lithium Battery Charger)</string>
     <string name="label_ecu_linsch">LINSCH (?)</string>
     <string name="default_zero">0</string>


### PR DESCRIPTION
Cleaned up driving UI (removed useless header above speed, added a triple dot menu for consistancy, fired up the numerical keyboard immediately when activating the distToDest popup.
