### PR TITLE
Duty cycle to Pilot current formula correction

### DIFF
--- a/app/src/main/java/lu/fisch/canze/actors/Fields.java
+++ b/app/src/main/java/lu/fisch/canze/actors/Fields.java
@@ -591,7 +591,7 @@ public class Fields {
                     if ((privateField = dependantFields.get(SID_ACPilotDutyCycle)) == null)
                         return Double.NaN;
                     double dutyCycle = privateField.getValue();
-                    return dutyCycle < 80.0 ? dutyCycle * 0.6 : 48.0 + (dutyCycle - 80.0) * 2;
+                    return dutyCycle < 80.0 ? dutyCycle * 0.6 : (dutyCycle - 64.0) * 2.5;
                 }
             });
 


### PR DESCRIPTION
Continuing from #600 

I just tested the new build on a public charger rated for 32A and the pilot was 32A exactly, which is reasonable. Previously in old non-ISOTP mode it was always showing something like 30, which I was puzzled about, but not enough to care. Now after I've verified the actual PWM on a portable EVSE I think the newest pilot code shows a much more accurate value for some reason.

Except that bit about 66A on a 43 kW charger. This value seemed out of place for European environment, I don't recall any breakers or relays rated at this figure, neither any car able to draw so much, closest being Zoe with 64A (there may still be some American cars doing up to 80A monophase, but never heard of such here anyway). 

So now that I know the "odd figures on public chargers" were a CanZE quirk all along, I assumed the number should be 64A and found an inconsistency in the formula for the higher amps. Backtracking with the current code for the 66A and applying a correct formula gives:
```
66A = 48 + (dc - 80) * 2
dc = 89%
amps = 62.5A
```

Which is closer to the expected 64A and the DC is off by less that 1%, indicating room for rounding. This new formula being by the book, I think this change will make the amps as correct as possible for all ranges.