### PR TITLE
ZE50 strings for Ukrainian and Russian

### DIFF
--- a/app/src/main/java/lu/fisch/canze/activities/SettingsCustomActivity.java
+++ b/app/src/main/java/lu/fisch/canze/activities/SettingsCustomActivity.java
@@ -34,8 +34,6 @@ public class SettingsCustomActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_settings_custom);
 
-        this.setTitle("Custom fragment settings");
-
         all = (ListView) findViewById(R.id.lstAll);
         all.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
         ArrayAdapter adapter = new ArrayAdapter<String>(getApplicationContext(),

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,8 +27,28 @@
     <string name="button_Tires">Шины</string>
     <string name="button_Tires_read">считать</string>
     <string name="button_Tires_write">записать</string>
+    <string-array name="list_TireStatus">
+        <item>OK</item>
+        <item>Нет инфо</item>
+        <item>Перекачана</item>
+        <item>-</item>
+        <item>Пустая</item>
+        <item>Пустая</item>
+        <item>Недокачана</item>
+        <item>-</item>
+    </string-array>
     <string name="button_alldata">Все данные</string>
-    <string name="button_AuxBatt">12В батарея</string>
+    <string name="button_AuxBatt">Совет по замене</string>
+        <string-array name="list_AuxStatus">
+        <item>Нет</item>
+        <item>1</item>
+        <item>2</item>
+        <item>Скоро</item>
+        <item>4</item>
+        <item>Сейчас</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
     <string name="button_chargingHistory">История зарядок</string>
     <string name="default_Cancel">Отмена</string>
     <string name="default_No">Нет</string>
@@ -63,10 +83,14 @@
     <string name="label_PtcRelay1">Реле PTC-термистора 1</string>
     <string name="label_PtcRelay2">Реле PTC-термистора 2</string>
     <string name="label_PtcRelay3">Реле PTC-термистора 3</string>
+    <string-array name="list_PtcRelay">
+        <item>Вкл.</item>
+        <item>Выкл.</item>
+    </string-array>
     <string name="label_Phases">Фазы</string>
     <string name="label_Range">Дост. пробег</string>
     <string name="label_Fields">Поля</string>
-    <string name="label_Car">Автомобиль</string>
+    <string name="label_Car">Элетромобиль</string>
     <string name="label_12A">12В ток (А)</string>
     <string name="label_12V">12В напряжение (В)</string>
     <string name="graph_ModuleTemperatures">Температура модулей батареи (°C)</string>
@@ -87,13 +111,35 @@
     <string name="label_LogLevel">Уровень журналирования</string>
     <string name="label_LogToSdcard1">Журналирование на SD-карту 1</string>
     <string name="label_MainsCurrentType">Тип сети</string>
+    <string-array name="list_MainsCurrentType">
+        <item>Ошибка</item>
+        <item>AC монофазная</item>
+        <item>AC трёфазная</item>
+        <item>DC</item>
+        <item>AC двухфазная</item>
+    </string-array>
     <string name="label_MainsActivePowerConsumed">Активная мощность, потребляемая с сети (Вт)</string>
     <string name="label_Options">Опции</string>
     <string name="label_Plug">Состояние подключения</string>
+    <string-array name="list_ChargingStatus">
+        <item>Не заряжается</item>
+        <item>Ожидание (запланованное)</item>
+        <item>Завершено</item>
+        <item>В процессе</item>
+        <item>Ошибка</item>
+        <item>Ожидание</item>
+        <item>Лючок открыт</item>
+        <item>Недоступно</item>
+    </string-array>
+    <string-array name="list_PlugStatus">
+        <item>Не подключено</item>
+        <item>Подключено</item>
+    </string-array>
     <string name="label_StateOfCharge">Уровень заряда (SOC) (%)</string>
     <string name="label_TTF">Время полной зарядки (мин)</string>
     <string name="label_Temperatures">Температуры (°C)</string>
     <string name="label_TotKwh">Суммарное использование батаери (кВтч)</string>
+    <string name="label_TotKwhRegen">Суммарная энергия рекуперативного торможения (кВтч)</string>
     <string name="label_TripConsumption">Расход за поездку</string>
     <string name="label_TripDistance">Расстояние поездки</string>
     <string name="label_TripEnergy">Энергия за поездку (кВтч)</string>
@@ -109,7 +155,7 @@
     <string name="label_UserSOC">Доступный уровень заряда (%)</string>
     <string name="label_Volt">Напряжение ВВ батареи (В)</string>
     <string name="label_WheelTorque">Момент на колёсах</string>
-    <string name="label_auxbat">Напряжение, Состояние авто, Состояние зарядки</string>
+    <string name="label_auxbat">Напряжение, Состояние ЭМ, Состояние зарядки</string>
     <string name="label_auxbatvolt">Напряжение</string>
     <string name="label_debug">"Debug "</string>
     <string name="label_diff_friction_torque">Приложенный момент фрикционного тормоза (потери)</string>
@@ -118,7 +164,45 @@
     <string name="label_kWh100km">кВтч/100км</string>
     <string name="label_pedal">Положение педали</string>
     <string name="label_wheel_torque">Момент на колёсах</string>
-    <string name="label_vehiclestate">Состояние авто</string>
+    <string name="label_vehiclestate">Состояние ЭМ</string>
+    <string-array name="list_VehicleState">
+        <item>Спит, выкл. (0:красный)</item>
+        <item>Не спит, выкл. (1:зелёный)</item>
+        <item>Зажигание вкл. (2:синий)</item>
+        <item>Запускается (3:жёлтый)</item>
+        <item>Не спит, вкл. (4:голубой)</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
+    <string-array name="list_VehicleStatePh2">
+        <item>Спит, выкл. (0:красный)</item>
+        <item>Не спит, выкл. (1:зелёный)</item>
+        <item>Ожидает режим сна (2:синий)</item>
+        <item>Питание бортовой сети (3:жёлтый)</item>
+        <item>4</item>
+        <item>Зажигание вкл.</item>
+        <item>Запускается</item>
+        <item>Мотор активен</item>
+        <item>Автозапуск</item>
+        <item>Остановка мотора</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+    </string-array>
+    <string-array name="list_ChargingStatus2">
+        <item>Не заряджается (0:красный)</item>
+        <item>Ожидание (запланованное, 1:зелёный)</item>
+        <item>Завершено (2:синий)</item>
+        <item>В процессе (3:жёлтый)</item>
+        <item>Ошибка (4:голубой)</item>
+        <item>Ожидание (5:фиолетовый)</item>
+        <item>Лючок открыт (6:чёрный)</item>
+        <item>Недоступно (7:серый)</item>
+    </string-array>
     <string name="label_phaseCurrent">Фазовые токи (сред.кв.) 1/2/3 (А)</string>
     <string name="label_max_pilot">Пилотный сигнал тока (А)</string>
     <string name="label_max_charge">Максимум зарядки/реген. (кВт)</string>
@@ -153,9 +237,29 @@
     <string name="label_ETF">Остаток энергии до полного (кВтч)</string>
     <string name="label_ElecBrakeWheelsTorqueApplied">Приложенный электрический момент (регенерация)</string>
     <string name="label_EndBatteryTemp">Темп.</string>
-    <string name="label_EndOfChargeStatus">Конец</string>
+    <string name="label_EndOfChargeStatus">Итог</string>
+    <string-array name="list_ChargingHistEnd">
+        <item>Полный</item>
+        <item>Отключено</item>
+        <item>Обесточено</item>
+        <item>Не удалось</item>
+        <item>По графику</item>
+        <item>Ошибка 1</item>
+        <item>Ошибка 22</item>
+        <item>Ошибка 3</item>
+        <item>Ошибка 4</item>
+        <item>Ошибка 5</item>
+        <item>Ошибка 6</item>
+    </string-array>
+    <string-array name="list_ChargingHistTyp">
+        <item>Медлен.</item>
+        <item>Быстр.</item>
+        <item>Замена</item>
+        <item>Неизв.</item>
+        <item>План.</item>
+    </string-array>
     <string name="label_EndSoc">SOC</string>
-    <string name="label_RangeRemaining">Пробег согласно авто:</string>
+    <string name="label_RangeRemaining">Пробег согласно ЭМ:</string>
     <string name="label_RangeRemainingCanZE">Пробег согласно CanZE:</string>
     <string name="label_RealSOC">Настоящий уровень заряда (%)</string>
     <string name="label_RemoteDevice">Удаленное устройство</string>
@@ -165,6 +269,43 @@
     <string name="label_Soc">SOC (%)</string>
     <string name="label_StateAtThisMoment">Состояние на сейчас</string>
     <string name="label_SupervisorState">Состояние супервизора</string>
+    <string-array name="list_SupervisorState">
+        <item>Начало</item>
+        <item>Ожидание</item>
+        <item>Замыкание S2</item>
+        <item>Иниц. Типа</item> <!--TODO-->
+        <item>Иниц. Утечки</item> <!--TODO-->
+        <item>Иніц. Заряда</item> <!--TODO-->
+        <item>Зарядка</item>
+        <item>Режим нуля ампер</item>
+        <item>Конец зарядки</item>
+        <item>Размыкание S2</item>
+        <item>Готовность ко сну</item>
+        <item>Аварийная остановка</item>
+        <item>InitChargeDF</item> <!--TODO-->
+        <item>OCPStop</item> <!--TODO-->
+        <item>Ожидание S2</item>
+    </string-array>
+    <string-array name="list_SupervisorStatePh2">
+        <item>Начало</item>
+        <item>StandByPowerOn</item> <!--TODO-->
+        <item>Замыкание S2</item>
+        <item>Иниц. Типа</item> <!--TODO-->
+        <item>Иниц. Утечки</item> <!--TODO-->
+        <item>StandByPowerOnSetup</item> <!--TODO-->
+        <item>Зарядка</item>
+        <item>Режим нуля ампер</item>
+        <item>Конец зарядки</item>
+        <item>OpeningRL</item> <!--TODO is this S2? -->
+        <item>STestOK</item> <!--TODO-->
+        <item>-</item>
+        <item>STestWait</item> <!--TODO-->
+        <item>STestAct</item> <!--TODO-->
+        <item>WaitRLCHA</item> <!--TODO-->
+        <item>WaitRLContactorTri</item> <!--TODO-->
+        <item>OpeningCapaMC</item> <!--TODO-->
+        <item>-</item>
+    </string-array>
     <string name="label_TireSpdPresMisadaption">Ошибка адаптации скорости-давления</string>
     <string name="title_activity_settings">Настройки</string>
     <string name="toast_BluetoothLost">Потеряно соединение Bluetooth!</string>
@@ -208,9 +349,164 @@
     <string name="label_ClearCachedData">Очистить кешированные данные</string>
     <string name="label_ClimaLoopMode">Цикл работы климатизации</string>
     <string name="label_ClimateBatteryInteraction">Взаимодействие батареи и климатизации</string>
+    <string-array name="list_CoolingStatus">
+        <item>Нет</item>
+        <item>Только охлаждение</item> <!--TODO-->
+        <item>Объединенное охлаждение</item> <!--TODO-->
+        <item>Недоступно</item>
+    </string-array>
+    <string-array name="list_ConditioningStatus">
+        <item>Необходима вентиляция</item>
+        <item>Необходимо охлаждение</item>
+        <item>Необходим подогрев</item>
+        <item>Кондиционирование ненужно</item>
+    </string-array>
+    <string-array name="list_ConditioningStatusPh2">
+        <item>Нет</item>
+        <item>Объединенное охлаждение салона воздухом</item> <!--TODO-->
+        <item>Объединенное охлаждение батареи воздухом</item> <!--TODO-->
+        <item>Только охлаждение батареи воздухом</item> <!--TODO-->
+        <item>Объединенное охлаждение салона</item> <!--TODO-->
+    </string-array>
+    <string-array name="list_ClimateStatus">
+        <item>Недступно</item>
+        <item>Кондиционер</item>
+        <item>Кондиционер (разморозка)</item>
+        <item> </item>
+        <item>Тепловой насос</item>
+        <item> </item>
+        <item>Распотевание</item>
+        <item>Режим простоя</item>
+    </string-array>
+    <string-array name="list_ClimateStatusPh2">
+        <item>Недступно</item>
+        <item>Кондиционер</item>
+        <item>Кондиционер (разморозка)</item>
+        <item>От кондиционера к тепловому насосу</item> <!--TODO-->
+        <item>Тепловой насос</item>
+        <item>От теплового насоса к кондиционеру</item> <!--TODO-->
+        <item>-</item>
+        <item>Режим простоя</item>
+    </string-array>
     <string name="label_CountFull">Полных зарядок (#)</string>
     <string name="label_CountPartial">Частичных зарядок (#)</string>
     <string name="label_CompletionStatus">Состояние завершения</string>
+    <string-array name="list_CompletionStatus">
+        <item>Начало</item>
+        <item>ВЧ10</item>
+        <item>-</item>
+        <item>Проблема с заземлением</item> <!--TODO-->
+        <item>-</item>
+        <item>Ток в заземление</item> <!--TODO-->
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Проблема с массой</item> <!--TODO-->
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка DC</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка НЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка DC+НЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка DC+ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка НЧ+ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Утечка DC+НЧ+ВЧ</item>
+    </string-array>
     <string name="label_ChargingPrediction">Прогноз зарядки</string>
     <string name="label_ChaStatus">Состояние зарядки</string>
     <string name="message_clear">Очистить</string>
@@ -238,7 +534,7 @@
     <string name="prompt_NoSd">" Внешняя SD-карта не доступна, защищена от записи или имеет недостаточный остаток емкости для записи данных журнала.<br /><br /><b>Невозможно влючить экспорт данных!</b>"</string>
     <string name="prompt_WarningDriving">Не уделять полного внимания дорожной обстановке во время движения крайне опасно и подвергает угрозе вашу жизнь и жизни окружающих. Выключение этого режима совершенно не рекомендуется.\n\nВы уверены, что действительно хотите отключить режим блокировки во время движения?</string>
     <string name="message_NoClearDtcField">Поле сброса ошибки (DTC) не существует</string>
-    <string name="message_MessageNull">Значение Msg равно null. Включено ли авто?\n</string>
+    <string name="message_MessageNull">Значение Msg равно null. Включен ли ЭМ?\n</string>
     <string name="message_DevicePassed">"\nВаше устройство прошло все тесты, скорее всего оно будет работать отлично "</string>
     <string name="message_GetDtcs">\nПосылаю начало последовательности ошибок (DTC):[</string>
     <string name="message_HardResetFailed">Полная перезагрузка не сработала, перезапускаю Bluetooth…</string>
@@ -247,7 +543,7 @@
     <string name="help_QA"><![CDATA[Более детальная информация об этих данных можно найти в <a href=\'http://canze.fisch.lu/qa/\'>разделе Q & A</a> <a href=\'http://canze.fisch.lu/\'>домашней страницы CanZE</a>.]]></string>
     <string name="help_Fields">Журналирует все поля, запрошенные текущим экраном.</string>
     <string name="help_Experimental">Эти кнопки предназначены исключительно для тестирования</string>
-    <string name="help_Ecus"><![CDATA[Нажмите на ЭБУ для получения детальной информации. Больше информации о компьютерах в авто <a href="http://canze.fisch.lu/computers/">тут</a>.]]></string>
+    <string name="help_Ecus"><![CDATA[Нажмите на ЭБУ для получения детальной информации. Больше информации о компьютерах в ЭМ <a href="http://canze.fisch.lu/computers/">тут</a>.]]></string>
     <string name="help_DTC">Чтобы включить возможность очистки ошибок (DTC):\n\nВставьте ключ-карту\n\nСелектор передач в  D\n\nЗажмите кнопку START приблизительно на 5 секунд, пока не появится сообщение «Remove card»\n\nСелектор передач в P</string>
     <string name="message_NoConnection">\nНет связи. Закройте этот экран и убедитесь, что ваше устройство включено и с ним создана пара\n</string>
     <string name="message_NoEcuDefinition">\nНе могу найти определения для этого ЭБУ. Возможно лишь отображение кодов ошибок (DTC)\n</string>
@@ -261,17 +557,149 @@
     <string name="default_NotOk">Не ОК</string>
     <string name="label_AltFields">Использовать поля ISOTP</string>
     <string name="label_Darkmode">Принудительный Тёмный Режим</string>
-    <string name="message_gotfirst">Got first value…</string>
-    <string name="message_gotsecond">Got second value…</string>
-    <string name="message_waitsecond">Waiting for second value…</string>
-    <string name="title_activity_research">Research</string>
-    <string name="title_activity_speedcontrol">Average speed</string>
-    <string name="message_NoFreeTesting">\nNot testing free frames, as you selected Use ISOTP fields\n</string>
-    <string name="label_TapToStart">Tap anywhere to start or reset</string>
-    <string name="label_averageSpeed">Average speed</string>
-    <string name="button_Research">Research</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
-    <string name="menu_Custom">Custom</string>
-    <string name="button_speedcontrol">Avg speed</string>
-    <string name="title_activity_settingscustom">Custom button settings</string>
+    <string name="message_gotfirst">Получено первое значение…</string>
+    <string name="message_gotsecond">Получено второе значение…</string>
+    <string name="message_waitsecond">Ожидание второго значения…</string>
+    <string name="title_activity_research">Исследование</string>
+    <string name="title_activity_speedcontrol">Средняя скорость</string>
+    <string name="message_NoFreeTesting">\nНе проверяем свободные кадры, так как вы выбрали использование полей ISOTP\n</string>
+    <string name="label_TapToStart">Нажмите в любом месте для начала или сброса</string>
+    <string name="label_averageSpeed">Средняя скорость</string>
+    <string name="button_Research">Исследование</string>
+    <string name="hello_blank_fragment">Привет, пустой фрагмент</string>
+    <string name="menu_Custom">Персонализированный экран</string>
+    <string name="button_speedcontrol">Ср. скорость</string>
+    <string name="title_activity_settingscustom">Настройка персонализированного экрана</string>
+    <string name="CPLCComStatus">Состояние связи высокого уровня (HLC)</string>
+    <string-array name="list_CPLCComStatus">
+        <item>Связь HLC не установлена</item>
+        <item>Начало связи HLC</item>
+        <item>Связь HLC готова - безопасный режим</item>
+        <item>Связь HLC остановлена</item>
+        <item>Ошибка связи HLCr</item>
+        <item>Связь HLC готова - небезопасный режим</item>
+        <item>Не используется</item>
+        <item>Недоступное значение[начальное значение]</item>
+        <item>Связь HLC не готова - ошибка установки TLS</item>
+        <item>Связь HLC не готова - таймаут TLS</item>
+        <item>Связь HLC не готова - TLS не поддерживается</item>
+        <item>Связь HLC не готова - таймаут SDP</item>
+        <item>Связь HLC не готова - версия ISO-2 не поддерживается</item>
+        <item>Связь HLC не готова - таймаут установки V2G</item>
+        <item>Связь HLC не готова - ошибка V2G</item>
+    </string-array>
+    <string name="EVReady">Готовность ЭМ</string>
+    <string-array name="list_EVReady">
+        <item>ЭМ не готов к зарядке</item>
+        <item>ЭМ готов к зарядке</item>
+    </string-array>
+    <string name="EVSEVoltageLimitReached">Досягнуто предельное напряжение зарядки DC</string>
+    <string name="EVSECurrentLimitReached">Досягнут предельный ток зарядки DC</string>
+    <string name="EVSEPowerLimitReached">Досягнута предельная мощность зарядки DC</string>
+    <string-array name="list_EVSELimitReached">
+        <item>Нет</item>
+        <item>Да</item>
+    </string-array>
+    <string name="EVRequestState">Запрос от ЭМ</string>
+    <string-array name="list_EVRequestState">
+        <item>Нет запроса по HLC</item>
+        <item>Запрос настроек связи и сервисов</item>
+        <item>Запрос обнаружения параметров зарядки</item>
+        <item>Запрос проверки кабеля</item>
+        <item>Запрос предварительнй зарядки</item>
+        <item>Запрос подключения мощности</item>
+        <item>Запрос заказа тока</item>
+        <item>Запрос показаний счётчика</item> <!--TODO is this money or kWh? -->
+        <item>Запрос проверки сплавления контактов</item>
+        <item>Запрос остановки сессии</item>
+        <item>Сброс паросочетания</item> <!--TODO-->
+        <item>Запрос состояния зарядки</item>
+        <item>AC BPT</item> <!--TODO-->
+        <item>DC BPT</item> <!--TODO-->
+    </string-array>
+    <!-- Translator: I don't quite like those, but literal translation would be wordy -->
+    <string name="EVSEState">Ответы зарядной станции</string>
+    <string-array name="list_EVSEState">
+        <item>Связь HLC не установлена</item>
+        <item>Установлены настройки связи и сервисов</item>
+        <item>Ответ обнаружения параметров зарядки</item>
+        <item>Ответ проверки кабеля</item>
+        <item>Ответ предварительной зарядки</item>
+        <item>Ответ подключения мощности</item>
+        <item>Ответ заказа тока</item>
+        <item>Ответ показаний счётчика</item>
+        <item>Ответ проверки сплавления контактов</item>
+        <item>Ответ остановки сессии</item> <!--TODO: with EVSE(station charging)-->
+        <item>Ответ состояния зарядки</item>
+    </string-array>
+    <string name="EVSEMaxCurrent">Максимальный ток зарядки DC (А)</string>
+    <string name="EVSEMaxPower">Максимальная мощность зарядки DC (Вт)</string>
+    <string name="EVSEMaxVoltage">Максимальное напряжение зарядки DC (В)</string>
+    <string name="EVSEPresentCurrent">Текущий ток зарядки DC (А)</string>
+    <string name="EVSEPresentVoltage">Текущее напряжение зарядки DC (В)</string>
+    <string name="EVSEFailureStatus">Наличие ошибок</string>
+    <string-array name="list_EVSEFailureStatus">
+        <item>Нет ошибки</item>
+        <item>Истекает срок действия сертификата</item>
+        <item>ОШИБКА Срок действия сертификата истёк</item>
+        <item>ОШИБКА Договор разорван</item>
+        <item>ОШИБКА Сертификат отозван</item>
+        <item>ОШИБКА Сертификат не разрешен на этой станции</item>
+        <item>ОШИБКА Отсутствует сертификат</item>
+        <item>ОШИБКА Неправильный режим передачи энергии</item>
+        <item>ОШИБКА Неправильный параметр зарядки</item>
+        <item>ОШИБКА Неправильный профиль зарядки</item>
+        <item>ОШИБКА Неправильный идентификатор сервиса</item>
+        <item>ОШИБКА Неизвестная сессия</item>
+        <item>ОШИБКА Неправильный выбор сервиса</item>
+        <item>ОШИБКА Неправильный выбор тарифа</item>
+        <item>ОШИБКА Неправильный выбор оплаты</item>
+        <item>ОШИБКА Ошибка в цепи сертификатов</item>
+        <item>ОШИБКА Неправильный ответ</item> <!--TODO Challenge -->
+        <item>ОШИБКА Неверная подпись показаний счётчика</item>
+        <item>ОШИБКА Не выбран сервис зарядки</item>
+        <item>ОШИБКА Ошибка коду последовательности</item>
+        <item>ОШИБКА Ошибка подписи</item>
+        <item>ОШИБКА Отсутствует сертификат</item> <!-- TODO double value? -->
+        <item>ОШИБКА Не применено подключение мощности</item>
+        <item>ОШИБКА</item>
+        <item>ОШИБКА Ошибка контактора</item>
+    </string-array>
+    <string name="EVSEStatus">Состояние зарядной станции</string>
+    <string-array name="list_EVSEStatus">
+        <item>Ок</item>
+        <item>Станция не готова</item>
+        <item>Станция выключается</item>
+        <item>Перерыв работы электросети</item> <!-- TODO -->
+        <item>Мониторинг изоляции в процессе</item>
+        <item>Аварийное отключение</item>
+        <item>Неисправность</item>
+        <item>Зарезервировано 8-C</item>
+        <item>Необходима повторная установка связи</item> <!-- TODO -->
+    </string-array>
+    <string name="header_EVSEParameters">Параметры CCS</string>
+    <string name="label_CanSeeSettings">Настройки CanSee</string>
+    <string name="label_CarModel">Модель</string>
+    <string name="label_ConfigureCustomFragment">Настройка персонализированного экрана</string>
+    <string name="label_Display">Экран</string>
+    <string name="label_DistanceUnit">Единицы измерения</string>
+    <string name="label_Info">Информация</string>
+    <string name="label_Kilometers">Километры</string>
+    <string name="label_Logging">Журналирование</string>
+    <string name="label_LoggingSettings">Настройки журналирования</string>
+    <string name="label_LogLevelSummary">Уровень отображения сообщений режима отладки</string>
+    <string name="label_Security">Безопасность</string>
+    <string name="label_Settings_Device">Устройство</string>
+    <string name="label_StartupActivity">Начальный экран</string>
+    <string name="label_Theme">Цветовая схема</string>
+    <string name="label_ThemeDark">Тёмная</string>
+    <string name="label_ThemeFollowSystem">Как в системе</string>
+    <string name="label_ThemeLight">Светлая</string>
+    <string name="label_ThermalComfortPower">Потребление мощности климат-контроля (Вт)</string>
+    <string name="label_ToastLevelElm">Устройство</string>
+    <string name="label_ToastLevelElmCar">Все</string>
+    <string name="label_ToastLevelNone">Никаких</string>
+    <string name="title_activity_ZE50Test">Тест ZE50</string>
+    <string name="toast_PleaseUseTop">Пожалуйста, воспользуйтесь кнопками наверху, чтобый выйти из настроек …</string>
+    <string name="toast_WaitingSettings">Остановка Bluetooth. Настройки загружаются. Подождите, пожалуйста …</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -27,6 +27,16 @@
     <string name="button_Tires">Шини</string>
     <string name="button_Tires_read">зчитати</string>
     <string name="button_Tires_write">записати</string>
+    <string-array name="list_TireStatus">
+        <item>OK</item>
+        <item>Немає інфо</item>
+        <item>Перекачана</item>
+        <item>-</item>
+        <item>Порожня</item>
+        <item>Порожня</item>
+        <item>Недокачана</item>
+        <item>-</item>
+    </string-array>
     <string name="button_alldata">Всі дані</string>
     <string name="button_AuxBatt">12В батарея</string>
     <string name="button_chargingHistory">Історія зарядок</string>
@@ -39,7 +49,7 @@
     <string name="format_DumpWriting" formatted="false">Зачекайте, йде запис %s</string>
     <string name="format_NoAsset" formatted="false">Немає доступу до %s</string>
     <string name="format_NoSid" formatted="false">%s: sid %s відсутній у класі Fields</string>
-    <string name="format_NoView">Немає екрану з id \'%$1s%$2s\'</string>
+    <string name="format_NoView" formatted="false">Немає екрану з id \'%s%s\'</string>
     <string name="graph_CellVoltages">Напруга на комірках (В)</string>
     <string name="graph_Climatech">Ззовні (°C), Всередині (°C), Замовлення (°C), Батарея (°C)</string>
     <string name="graph_DistanceEnergy">Наявний пробіг (км), наявна енергія (кВтг)</string>
@@ -60,12 +70,16 @@
     <string name="prompt_SetDistance">Будь ласка, введіть відстань до пункту призначення. На екрані відображатиметься прогноз залишку пробігу, наявного у вашій батареї по прибутті</string>
     <string name="prompt_Distance">ЗАЛИШОК ПРОБІГУ</string>
     <string name="label_PtcRelay1">Реле PTC-термістору 1</string>
-    <string name="label_PtcRelay2">Реле PTC-термістору 1</string>
-    <string name="label_PtcRelay3">Реле PTC-термістору 1</string>
+    <string name="label_PtcRelay2">Реле PTC-термістору 2</string>
+    <string name="label_PtcRelay3">Реле PTC-термістору 3</string>
+    <string-array name="list_PtcRelay">
+        <item>Увімк.</item>
+        <item>Вимк.</item>
+    </string-array>
     <string name="label_Phases">Фази</string>
     <string name="label_Range">Наяв. пробіг</string>
     <string name="label_Fields">Поля</string>
-    <string name="label_Car">Автівка</string>
+    <string name="label_Car">Електроавтівка</string>
     <string name="label_12A">12В струм (А)</string>
     <string name="label_12V">12В напруга (В)</string>
     <string name="graph_ModuleTemperatures">Температура модулів батареї (°C)</string>
@@ -86,13 +100,35 @@
     <string name="label_LogLevel">Рівень журналювання</string>
     <string name="label_LogToSdcard1">Журналювання на SD-карту 1</string>
     <string name="label_MainsCurrentType">Тип мережі</string>
+    <string-array name="list_MainsCurrentType">
+        <item>Помилка</item>
+        <item>AC монофазна</item>
+        <item>AC трифазна</item>
+        <item>DC</item>
+        <item>AC двохфазна</item>
+    </string-array>
     <string name="label_MainsActivePowerConsumed">Активна потужність, що споживається з мережі (Вт)</string>
     <string name="label_Options">Опції</string>
     <string name="label_Plug">Стан підключення</string>
+    <string-array name="list_ChargingStatus">
+        <item>Не заряджається</item>
+        <item>Очікування (заплановане)</item>
+        <item>Завершено</item>
+        <item>В процесі</item>
+        <item>Помилка</item>
+        <item>Очікування</item>
+        <item>Лючок відчинений</item>
+        <item>Недоступно</item>
+    </string-array>
+    <string-array name="list_PlugStatus">
+        <item>Не підключено</item>
+        <item>Підключено</item>
+    </string-array>
     <string name="label_StateOfCharge">Рівень заряду (SOC) (%)</string>
     <string name="label_TTF">Час повної зарядки (хв)</string>
     <string name="label_Temperatures">Температури (°C)</string>
     <string name="label_TotKwh">Сумарне використання батареї (кВтг)</string>
+    <string name="label_TotKwhRegen">Сумарна енергія рекуперативного гальмування (кВтг)</string>
     <string name="label_TripConsumption">Споживання за поїздку</string>
     <string name="label_TripDistance">Відстань поїздки</string>
     <string name="label_TripEnergy">Енергія за поїздку (кВтг)</string>
@@ -108,7 +144,7 @@
     <string name="label_UserSOC">Наявний рівень заряду (%)</string>
     <string name="label_Volt">Напруга ВВ батареї (В)</string>
     <string name="label_WheelTorque">Момент на колесах</string>
-    <string name="label_auxbat">Напруга, Стан авто, Стан зарядки</string>
+    <string name="label_auxbat">Напруга, Стан ЕМ, Стан зарядки</string>
     <string name="label_auxbatvolt">Напруга</string>
     <string name="label_debug">"Debug "</string>
     <string name="label_diff_friction_torque">Прикладений момент фрикційних гальм (втрати)</string>
@@ -117,7 +153,45 @@
     <string name="label_kWh100km">кВтг/100км</string>
     <string name="label_pedal">Положення педалі</string>
     <string name="label_wheel_torque">Момент на колесах</string>
-    <string name="label_vehiclestate">Стан авто</string>
+    <string name="label_vehiclestate">Стан ЕМ</string>
+    <string-array name="list_VehicleState">
+        <item>Спить, вимк. (0:червоний)</item>
+        <item>Не спить, вимк. (1:зелений)</item>
+        <item>Запалювання увімк. (2:синій)</item>
+        <item>Запускається (3:жовтий)</item>
+        <item>Не спить, увімк. (4:блакитний)</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
+    <string-array name="list_VehicleStatePh2">
+        <item>Спить, вимк. (0:червоний)</item>
+        <item>Не спить, вимк. (1:зелений)</item>
+        <item>Очікує режим сну (2:синій)</item>
+        <item>Живлення бортової мережі (3:жовтий)</item>
+        <item>4</item>
+        <item>Запалювання увімк.</item>
+        <item>Запускається</item>
+        <item>Мотор активний</item>
+        <item>Автозапуск</item>
+        <item>Зупинка мотора</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+    </string-array>
+    <string-array name="list_ChargingStatus2">
+        <item>Не заряджається (0:червоний)</item>
+        <item>Очікування (заплановане, 1:зелений)</item>
+        <item>Завершено (2:синій)</item>
+        <item>В процесі (3:жовтий)</item>
+        <item>Помилка (4:блакитний)</item>
+        <item>Очікування (5:бузковий)</item>
+        <item>Лючок відчинений (6:чорний)</item>
+        <item>Недоступно (7:сірий)</item>
+    </string-array>
     <string name="label_phaseCurrent">Фазові струми (серед.кв.) 1/2/3 (А)</string>
     <string name="label_max_pilot">Пілотний сигнал струму (А)</string>
     <string name="label_max_charge">Максимум зарядки/реген. (кВт)</string>
@@ -136,6 +210,16 @@
     <string name="label_Actions">Дії</string>
     <string name="label_Amps">Струм ВВ батареї (А)</string>
     <string name="label_AuxStatus">Порада щодо заміни</string>
+    <string-array name="list_AuxStatus">
+        <item>Немає</item>
+        <item>1</item>
+        <item>2</item>
+        <item>Скоро</item>
+        <item>4</item>
+        <item>Зараз</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
     <string name="label_AvChPwr">Наявна потужність зарядки (кВт)</string>
     <string name="label_AvEner">Наявна енергія (кВтг)</string>
     <string name="label_BatteryTemperature">Температура батареї (°C)</string>
@@ -152,9 +236,29 @@
     <string name="label_ETF">Залишок енергії до повного (кВтг)</string>
     <string name="label_ElecBrakeWheelsTorqueApplied">Прикладений електричний момент (регенерація)</string>
     <string name="label_EndBatteryTemp">Темп.</string>
-    <string name="label_EndOfChargeStatus">Кінець</string>
+    <string name="label_EndOfChargeStatus">Підсумок</string>
+    <string-array name="list_ChargingHistEnd">
+        <item>Повний</item>
+        <item>Вимкнено</item>
+        <item>Знеструмлено</item>
+        <item>Не вдалось</item>
+        <item>За графіком</item>
+        <item>Помилка 1</item>
+        <item>Помилка 22</item>
+        <item>Помилка 3</item>
+        <item>Помилка 4</item>
+        <item>Помилка 5</item>
+        <item>Помилка 6</item>
+    </string-array>
+    <string-array name="list_ChargingHistTyp">
+        <item>Повіль.</item>
+        <item>Швидк.</item>
+        <item>Заміна</item>
+        <item>Невід.</item>
+        <item>План.</item>
+    </string-array>
     <string name="label_EndSoc">SOC</string>
-    <string name="label_RangeRemaining">Пробіг згідно авто:</string>
+    <string name="label_RangeRemaining">Пробіг згідно ЕМ:</string>
     <string name="label_RangeRemainingCanZE">Пробіг згідно CanZE:</string>
     <string name="label_RealSOC">Справжній рівень заряду (%)</string>
     <string name="label_RemoteDevice">Віддаленний пристрій</string>
@@ -164,6 +268,43 @@
     <string name="label_Soc">SOC (%)</string>
     <string name="label_StateAtThisMoment">Стан на зараз</string>
     <string name="label_SupervisorState">Стан супервізору</string>
+    <string-array name="list_SupervisorState">
+        <item>Початок</item>
+        <item>Очікування</item>
+        <item>Замикання S2</item>
+        <item>Ініц. Типу</item> <!--TODO-->
+        <item>Ініц. Витоку</item> <!--TODO-->
+        <item>Ініц. Заряду</item> <!--TODO-->
+        <item>Зарядка</item>
+        <item>Режим нуля ампер</item>
+        <item>Кінець зарядки</item>
+        <item>Розімкнення S2</item>
+        <item>Готовність до сну</item>
+        <item>Аварійна зупинка</item>
+        <item>InitChargeDF</item> <!--TODO-->
+        <item>OCPStop</item> <!--TODO-->
+        <item>Очікування S2</item>
+    </string-array>
+    <string-array name="list_SupervisorStatePh2">
+        <item>Початок</item>
+        <item>StandByPowerOn</item> <!--TODO-->
+        <item>Замикання S2</item>
+        <item>Ініц. Типу</item> <!--TODO-->
+        <item>Ініц. Витоку</item> <!--TODO-->
+        <item>StandByPowerOnSetup</item> <!--TODO-->
+        <item>Зарядка</item>
+        <item>Режим нуля ампер</item>
+        <item>Кінець зарядки</item>
+        <item>OpeningRL</item> <!--TODO is this S2? -->
+        <item>STestOK</item> <!--TODO-->
+        <item>-</item>
+        <item>STestWait</item> <!--TODO-->
+        <item>STestAct</item> <!--TODO-->
+        <item>WaitRLCHA</item> <!--TODO-->
+        <item>WaitRLContactorTri</item> <!--TODO-->
+        <item>OpeningCapaMC</item> <!--TODO-->
+        <item>-</item>
+    </string-array>
     <string name="label_TireSpdPresMisadaption">Помилка адаптації швидкості-тиску</string>
     <string name="title_activity_settings">Налаштунки</string>
     <string name="toast_BluetoothLost">Втрачено з\'єднання Bluetooth!</string>
@@ -192,7 +333,7 @@
     <string name="title_activity_auxbatt">12В батарея</string>
     <string name="title_activity_alldata">Усі дані</string>
     <string name="prompt_YesIKnow">Так</string>
-    <string name="label_Miles">Мілі</string>
+    <string name="label_Miles">Милі</string>
     <string name="label_InterPhaseVoltage">Міжфазна напруга 12/23/31 (В)</string>
     <string name="label_InstantConsumption">Миттєве споживання</string>
     <string name="label_EngineFanSpeed">Швидкість вентилятору двигуна (%)</string>
@@ -208,9 +349,164 @@
     <string name="label_ClearCachedData">Очистити кешовані дані</string>
     <string name="label_ClimaLoopMode">Цикл роботи кліматизації</string>
     <string name="label_ClimateBatteryInteraction">Взаємодія батареї і кліматизації</string>
+    <string-array name="list_CoolingStatus">
+        <item>Ні</item>
+        <item>Лише охолодження</item> <!--TODO-->
+        <item>Об\'єднане охолодження</item> <!--TODO-->
+        <item>Недоступно</item>
+    </string-array>
+    <string-array name="list_ConditioningStatus">
+        <item>Потрібна вентиляція</item>
+        <item>Потрібне охолодження</item>
+        <item>Потрібний підігрів</item>
+        <item>Кондиціонування непотрібне</item>
+    </string-array>
+    <string-array name="list_ConditioningStatusPh2">
+        <item>Ні</item>
+        <item>Об\'єднане охолодження салону повітрям</item> <!--TODO-->
+        <item>Об\'єднане охолодження батареї повітрям</item> <!--TODO-->
+        <item>Лише охолодження батареї повітрям</item> <!--TODO-->
+        <item>Об\'єднане охолодження салону</item> <!--TODO-->
+    </string-array>
+    <string-array name="list_ClimateStatus">
+        <item>Недступно</item>
+        <item>Кондиціонер</item>
+        <item>Кондиціонер (розмороження)</item>
+        <item> </item>
+        <item>Тепловий насос</item>
+        <item> </item>
+        <item>Розпотівання</item>
+        <item>Режим простою</item>
+    </string-array>
+    <string-array name="list_ClimateStatusPh2">
+        <item>Недступно</item>
+        <item>Кондиціонер</item>
+        <item>Кондиціонер (розмороження)</item>
+        <item>Від кондиціонеру до теплового насосу</item> <!--TODO-->
+        <item>Тепловий насос</item>
+        <item>Від теплового насосу до кондиціонеру</item> <!--TODO-->
+        <item>-</item>
+        <item>Режим простою</item>
+    </string-array>
     <string name="label_CountFull">Повних зарядок (#)</string>
     <string name="label_CountPartial">Часткових зарядок (#)</string>
     <string name="label_CompletionStatus">Стан завершення</string>
+    <string-array name="list_CompletionStatus">
+        <item>Початок</item>
+        <item>ВЧ10</item>
+        <item>-</item>
+        <item>Проблема з заземленням</item> <!--TODO-->
+        <item>-</item>
+        <item>Струм у заземлення</item> <!--TODO-->
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Проблема з масою</item> <!--TODO-->
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік DC</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік НЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік DC+НЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік DC+ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік НЧ+ВЧ</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>-</item>
+        <item>Витік DC+НЧ+ВЧ</item>
+    </string-array>
     <string name="label_ChargingPrediction">Прогноз зарядки</string>
     <string name="label_ChaStatus">Стан зарядки</string>
     <string name="message_clear">Очистити</string>
@@ -238,7 +534,7 @@
     <string name="prompt_NoSd">Зовнішня SD-карта не доступна, захищена від запису або має недостатній залишок ємності для запису даних журналу.<br /><br /><b>Неможливо увімкнути експорт даних!</b></string>
     <string name="prompt_WarningDriving">Не приділяти повну увагу дорожній обстановці під час руху вкрай небезпечно та піддає загрозі ваше життя та життя оточуючих. Вимкнення цього режима абсолютно не рекомендовано!\n\nЧи ви впевнені, що дійсно хочете вимкнути режим блокування під час руху?</string>
     <string name="message_NoClearDtcField">"Поле скидання помилки  (DTC) не існує "</string>
-    <string name="message_MessageNull">Значення Msg дорівнює null. Чи авто увімкнене?\n</string>
+    <string name="message_MessageNull">Значення Msg дорівнює null. Чи ЕМ увімкнений?\n</string>
     <string name="message_DevicePassed">\nВаш пристрій пройшов всі тести, скоріше за все він буде працювати відмінно</string>
     <string name="message_GetDtcs">\nВідправляю початок послідовності помилок (DTC):[</string>
     <string name="message_InitFailed">\nПомилка ініціалізації</string>
@@ -246,7 +542,7 @@
     <string name="message_NoActiveDtcs">\nНемає активних помилок (DTC)</string>
     <string name="help_Fields">Журналює усі поля, що запитані поточним екраном.</string>
     <string name="help_Experimental">Ці кнопки призначені виключно для тестування</string>
-    <string name="help_Ecus"><![CDATA[Натисніть на ЕБУ для отримання детальної інформації. Більше інформації про комп\'ютери в авто <a href="http://canze.fisch.lu/computers/">тут</a>.]]></string>
+    <string name="help_Ecus"><![CDATA[Натисніть на ЕБУ для отримання детальної інформації. Більше інформації про комп\'ютери в ЕМ <a href="http://canze.fisch.lu/computers/">тут</a>.]]></string>
     <string name="help_DTC">Щоби увімкнути можливість очистки помилок  (DTC):\n\nВставте ключ-карту\n\nСелектор передач у  D\n\nЗатисніть кнопку START приблизно на 5 секунд, поки не з\'явиться повідомлення «Remove card»\n\nСелектор передач у P</string>
     <string name="help_QA"><![CDATA[Більш детальну інформацію про ці дані можна знайти у <a href=\'http://canze.fisch.lu/qa/\'>разділі Q & A</a> <a href=\'http://canze.fisch.lu/\'>домашньої сторінки CanZE</a>.]]></string>
     <string name="message_NoConnection">\nНемає зв\'язку. Зачініть цей екран і пересвідчіться, що ваш пристрій підключено та з ним утворено пару\n</string>
@@ -261,17 +557,149 @@
     <string name="default_NotOk">Не ОК</string>
     <string name="label_AltFields">Використовувати поля ISOTP</string>
     <string name="label_Darkmode">Примусовий Темний Режим</string>
-    <string name="message_gotfirst">Got first value…</string>
-    <string name="message_gotsecond">Got second value…</string>
-    <string name="message_waitsecond">Waiting for second value…</string>
-    <string name="title_activity_research">Research</string>
-    <string name="title_activity_speedcontrol">Average speed</string>
-    <string name="message_NoFreeTesting">\nNot testing free frames, as you selected Use ISOTP fields\n</string>
-    <string name="label_TapToStart">Tap anywhere to start or reset</string>
-    <string name="label_averageSpeed">Average speed</string>
-    <string name="button_Research">Research</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
-    <string name="menu_Custom">Custom</string>
-    <string name="button_speedcontrol">Avg speed</string>
-    <string name="title_activity_settingscustom">Custom button settings</string>
+    <string name="message_gotfirst">Отримано перше значення…</string>
+    <string name="message_gotsecond">Отримано друге значення…</string>
+    <string name="message_waitsecond">Очікування другого значення…</string>
+    <string name="title_activity_research">Дослідження</string>
+    <string name="title_activity_speedcontrol">Середня швидкість</string>
+    <string name="message_NoFreeTesting">\nНе перевіряємо вільні кадри, оскільки ви обрали використання полів ISOTP\n</string>
+    <string name="label_TapToStart">Натисніть у будь-якому місці для початку чи скидання</string>
+    <string name="label_averageSpeed">Середня швидкість</string>
+    <string name="button_Research">Дослідження</string>
+    <string name="hello_blank_fragment">Привіт, порожній фрагменте</string>
+    <string name="menu_Custom">Персоналізований екран</string>
+    <string name="button_speedcontrol">Сер. швидкість</string>
+    <string name="title_activity_settingscustom">Налаштування персоналізованого екрану</string>
+    <string name="CPLCComStatus">Стан зв\'язку високого рівня (HLC)</string>
+    <string-array name="list_CPLCComStatus">
+        <item>Зв\'язок HLC не встановлено</item>
+        <item>Початок зв\'язку HLC</item>
+        <item>Зв\'язок HLC готовий - безпечний режим</item>
+        <item>Зв\'язок HLC зупинений</item>
+        <item>Помилка зв\'язку HLCr</item>
+        <item>Зв\'язок HLC готовий - небезпечний режим</item>
+        <item>Не використовуєтся</item>
+        <item>Недоступне значення[початкове значення]</item>
+        <item>Зв\'язок HLC не готовий - помикла встановлення TLS</item>
+        <item>Зв\'язок HLC не готовий - таймаут TLS</item>
+        <item>Зв\'язок HLC не готовий - TLS не підтримується</item>
+        <item>Зв\'язок HLC не готовий - таймаут SDP</item>
+        <item>Зв\'язок HLC не готовий - версія ISO-2 не підтримується</item>
+        <item>Зв\'язок HLC не готовий - таймаут встановлення V2G</item>
+        <item>Зв\'язок HLC не готовий - помилка V2G</item>
+    </string-array>
+    <string name="EVReady">Готовність ЕМ</string>
+    <string-array name="list_EVReady">
+        <item>ЕМ не готовий до зарядки</item>
+        <item>ЕМ готовий до зарядки</item>
+    </string-array>
+    <string name="EVRequestState">Запит від ЕМ</string>
+    <string-array name="list_EVRequestState">
+        <item>Нема запиту по HLC</item>
+        <item>Запит налаштунків зв\'язку та сервісів</item>
+        <item>Запит знаходження параметрів зарядки</item>
+        <item>Запит перевірки кабелю</item>
+        <item>Запит попередьної зарядки</item>
+        <item>Запит підключення потужності</item>
+        <item>Запит замовлення струму</item>
+        <item>Запит показів лічильника</item> <!--TODO is this money or kWh? -->
+        <item>Запит перевірки сплавлення контактів</item>
+        <item>Запит зупинки сесії</item>
+        <item>Скидання парування</item> <!--TODO-->
+        <item>Запит стану зарядки</item>
+        <item>AC BPT</item> <!--TODO-->
+        <item>DC BPT</item> <!--TODO-->
+    </string-array>
+    <!-- Translator: I don't quite like those, but literal translation would be wordy -->
+    <string name="EVSEState">Відповіді зарядної станції</string>
+    <string-array name="list_EVSEState">
+        <item>Зв\'язок HLC не встановлено</item>
+        <item>Встановлені налаштунки зв\'язку та сервісів</item>
+        <item>Відповідь знаходження параметрів зарядки</item>
+        <item>Відповідь перевірки кабеля</item>
+        <item>Відповідь попередньої зарядки</item>
+        <item>Відповідь підключення потужності</item>
+        <item>Відповідь замовлення струму</item>
+        <item>Відповідь показів лічильника</item>
+        <item>Відповідь перевірки сплавлення контактів</item>
+        <item>Відповідь зупкинки сесії</item> <!--TODO: with EVSE(station charging)-->
+        <item>Відповідь стану зарядки</item>
+    </string-array>
+    <string name="EVSEVoltageLimitReached">Досягнуто граничної напруги зарядки DC</string>
+    <string name="EVSECurrentLimitReached">Досягнуто граничного струму зарядки DC</string>
+    <string name="EVSEPowerLimitReached">Досягнуто граничної потужності зарядки DC</string>
+    <string-array name="list_EVSELimitReached">
+        <item>Ні</item>
+        <item>Так</item>
+    </string-array>
+    <string name="EVSEMaxCurrent">Максимальний струм зарядки DC (А)</string>
+    <string name="EVSEMaxPower">Максимальна потужність зарядки DC (Вт)</string>
+    <string name="EVSEMaxVoltage">Максимальна напруга зарядки DC (В)</string>
+    <string name="EVSEPresentCurrent">Поточний струм зарядки DC (А)</string>
+    <string name="EVSEPresentVoltage">Поточна напруга зарядки DC (В)</string>
+    <string name="EVSEFailureStatus">Наявна помилка</string>
+    <string-array name="list_EVSEFailureStatus">
+        <item>Нема помилки</item>
+        <item>Витікає строк дії сертифікату</item>
+        <item>ПОМИЛКА Строк дії сертифікату витік</item>
+        <item>ПОМИЛКА Договір скасований</item>
+        <item>ПОМИЛКА Сертифікат відкликаний</item>
+        <item>ПОМИЛКА Сертифікат недозволений на цій станції</item>
+        <item>ПОМИЛКА Брак сертифікату</item>
+        <item>ПОМИЛКА Неправильний режим передачі енергії</item>
+        <item>ПОМИЛКА Неправильний параметр зарядки</item>
+        <item>ПОМИЛКА Неправильний профіль зарядки</item>
+        <item>ПОМИЛКА Неправильний ідентифікатор сервісу</item>
+        <item>ПОМИЛКА Невідома сесія</item>
+        <item>ПОМИЛКА Неправильний вибір сервісу</item>
+        <item>ПОМИЛКА Неправильний вибір тарифу</item>
+        <item>ПОМИЛКА Неправильний вибір оплати</item>
+        <item>ПОМИЛКА Помилка у ланцюгу сертифікатів</item>
+        <item>ПОМИЛКА Неправильна відповідь</item> <!--TODO Challenge -->
+        <item>ПОМИЛКА Невірний підис показників лічильнику</item>
+        <item>ПОМИЛКА Не обрано сервіс зарядки</item>
+        <item>ПОМИЛКА Помилка коду послідовності</item>
+        <item>ПОМИЛКА Помилка підпису</item>
+        <item>ПОМИЛКА Брак сертифікату</item> <!-- TODO double value? -->
+        <item>ПОМИЛКА Не застосовано підключення потужності</item>
+        <item>ПОМИЛКА</item>
+        <item>ПОМИЛКА Помилка контактору</item>
+    </string-array>
+    <string name="EVSEStatus">Стан зарядної станції</string>
+    <string-array name="list_EVSEStatus">
+        <item>Ок</item>
+        <item>Станція не готова</item>
+        <item>Станція вимикається</item>
+        <item>Перерва роботи електромережі</item> <!-- TODO -->
+        <item>Триває моніторинг ізоляції</item>
+        <item>Аварійне вимкнення</item>
+        <item>Несправність</item>
+        <item>Зарезервовано 8-C</item>
+        <item>Потрібне повторне встановлення зв\'язку</item> <!-- TODO -->
+    </string-array>
+    <string name="header_EVSEParameters">Параметри CCS</string>
+    <string name="label_CanSeeSettings">Налаштунки CanSee</string>
+    <string name="label_CarModel">Модель</string>
+    <string name="label_ConfigureCustomFragment">Налаштування персоналізованого екрану</string>
+    <string name="label_Display">Екран</string>
+    <string name="label_DistanceUnit">Одиниці виміру</string>
+    <string name="label_Info">Інформація</string>
+    <string name="label_Kilometers">Кілометри</string>
+    <string name="label_Logging">Журналювання</string>
+    <string name="label_LoggingSettings">Налаштунки журналювання</string>
+    <string name="label_LogLevelSummary">Рівень відображення повідомлень режиму налагоджування</string>
+    <string name="label_Security">Безпека</string>
+    <string name="label_Settings_Device">Пристій</string>
+    <string name="label_StartupActivity">Початковий екран</string>
+    <string name="label_Theme">Кольорова схема</string>
+    <string name="label_ThemeDark">Темна</string>
+    <string name="label_ThemeFollowSystem">Як в системі</string>
+    <string name="label_ThemeLight">Світла</string>
+    <string name="label_ThermalComfortPower">Споживання потужності клімат-контролю (Вт)</string>
+    <string name="label_ToastLevelElm">Пристрій</string>
+    <string name="label_ToastLevelElmCar">Всі</string>
+    <string name="label_ToastLevelNone">Жодних</string>
+    <string name="title_activity_ZE50Test">Тест ZE50</string>
+    <string name="toast_PleaseUseTop">Будь ласка, скористайтеся кнопками нагорі, щоб вийти з налаштунків …</string>
+    <string name="toast_WaitingSettings">Зупинка Bluetooth. Налаштунки завантажуються. Зачекайте, будь ласка …</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -824,7 +824,7 @@
 
     <!-- SettingsCustom -->
 
-    <string name="title_activity_settingscustom">Custom button settings</string>
+    <string name="title_activity_settingscustom">Custom fragment settings</string>
 
     <!-- Speed control -->
 


### PR DESCRIPTION
Might include small typos because a lot of text at once.
Some strings are translated by guesswork with `TODO` comments, mostly related to supervisor, completion status and some of CCS functionality.

AC/DC abbreviations left in Latin (unlike LF/HF) as per feedback from local drivers because native words are recognizable while their abbreviations are totally not.

Also Merry Christmas!

![image](https://user-images.githubusercontent.com/2434329/103143557-12cf4b00-4721-11eb-9159-036294faea24.png)
