### PR TITLE
Min/Max/Delta cell voltages in heatmap

### DIFF
--- a/app/src/main/java/lu/fisch/canze/activities/HeatmapCellvoltageActivity.java
+++ b/app/src/main/java/lu/fisch/canze/activities/HeatmapCellvoltageActivity.java
@@ -42,6 +42,7 @@ import lu.fisch.canze.interfaces.FieldListener;
 public class HeatmapCellvoltageActivity extends CanzeActivity implements FieldListener, DebugListener {
 
     private double mean = 0;
+    private double lowest, highest;
     private double cutoff;
     private final double[] lastVoltage = {0,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4};
     private final int lastCell = 96;
@@ -92,8 +93,8 @@ public class HeatmapCellvoltageActivity extends CanzeActivity implements FieldLi
             lastVoltage[cell] = value;
             if (cell == lastCell) {
                 mean = 0;
-                double lowest = 5;
-                double highest = 3;
+                lowest = 5;
+                highest = 3;
                 // lastVoltage[20] = 3.5; fake for test
                 for (int i = 1; i <= lastCell; i++) {
                     mean += lastVoltage[i];
@@ -103,7 +104,7 @@ public class HeatmapCellvoltageActivity extends CanzeActivity implements FieldLi
                 mean /= lastCell;
                 cutoff = lowest < 3.712 ? mean - (highest - mean) * 1.5 : 2;
 
-                        // the update has to be done in a separate thread
+                // the update has to be done in a separate thread
                 // otherwise the UI will not be repainted
                 runOnUiThread(new Runnable() {
                     @Override
@@ -115,6 +116,22 @@ public class HeatmapCellvoltageActivity extends CanzeActivity implements FieldLi
                                 tv.setText(String.format(Locale.getDefault(), "%.3f", lastVoltage[i]));
                                 int delta = (int) (5000 * (lastVoltage[i] - mean)); // color is temp minus mean. 1mV difference is 5 color ticks
                                 tv.setBackgroundColor(makeColor (delta));
+                            }
+                        }
+
+                        // Only update the high-low if we have realistic data
+                        if (highest >= lowest) {
+                            TextView tv = findViewById(R.id.text_CellVoltageTop);
+                            if (tv != null) {
+                                tv.setText(String.format("%.3f", highest));
+                            }
+                            tv = findViewById(R.id.text_CellVoltageBottom);
+                            if (tv != null) {
+                                tv.setText(String.format("%.3f", lowest));
+                            }
+                            tv = findViewById(R.id.text_CellVoltageDelta);
+                            if (tv != null) {
+                                tv.setText(String.format("%.3f", 1000 * (highest - lowest)));
                             }
                         }
                     }

--- a/app/src/main/java/lu/fisch/canze/activities/HeatmapCellvoltageActivity.java
+++ b/app/src/main/java/lu/fisch/canze/activities/HeatmapCellvoltageActivity.java
@@ -131,7 +131,7 @@ public class HeatmapCellvoltageActivity extends CanzeActivity implements FieldLi
                             }
                             tv = findViewById(R.id.text_CellVoltageDelta);
                             if (tv != null) {
-                                tv.setText(String.format("%.3f", 1000 * (highest - lowest)));
+                                tv.setText(String.format("%d", Math.round(1000 * (highest - lowest))));
                             }
                         }
                     }

--- a/app/src/main/res/layout/activity_heatmap_cellvoltage.xml
+++ b/app/src/main/res/layout/activity_heatmap_cellvoltage.xml
@@ -12,6 +12,51 @@
     >
 
     <TableLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TableRow>
+            <TextView
+                android:layout_weight="0.7"
+                android:width="0dp"
+                android:text="@string/label_CellVoltageTop" />
+            <TextView
+                android:id="@+id/text_CellVoltageTop"
+                android:layout_weight="0.3"
+                android:width="0dp"
+                android:gravity="end"
+                android:text="@string/default_Dash" />
+        </TableRow>
+
+        <TableRow>
+            <TextView
+                android:layout_weight="0.7"
+                android:width="0dp"
+                android:text="@string/label_CellVoltageBottom" />
+            <TextView
+                android:id="@+id/text_CellVoltageBottom"
+                android:layout_weight="0.3"
+                android:width="0dp"
+                android:gravity="end"
+                android:text="@string/default_Dash" />
+        </TableRow>
+
+        <TableRow>
+            <TextView
+                android:layout_weight="0.7"
+                android:width="0dp"
+                android:text="@string/label_CellVoltageDelta" />
+            <TextView
+                android:id="@+id/text_CellVoltageDelta"
+                android:layout_weight="0.3"
+                android:width="0dp"
+                android:gravity="end"
+                android:text="@string/default_Dash" />
+        </TableRow>
+
+    </TableLayout>
+
+    <TableLayout
         android:layout_width="fill_parent"
         android:layout_height="0dp"
         android:stretchColumns="*"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -622,18 +622,9 @@
 
     <string name="title_activity_heatmap_cellvoltage">Übersicht: Spannungen der einzelnen Akkuzellen</string>
     <string name="button_HeatmapVoltage">Übersicht Zellen-Spannung</string>
-
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+    <string name="label_CellVoltageTop">Höchste Zellen-Spannung (V)</string>
+    <string name="label_CellVoltageBottom">Niedrigste Zellen-Spannung (V)</string>
+    <string name="label_CellVoltageDelta">Zellen-Spannungsdifferenz (mV)</string>
     
     <!-- Kangoo fluence temperatures -->
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -424,6 +424,9 @@
     <string name="button_HeatmapTemperature">T° des modules</string>
     <string name="title_activity_heatmap_cellvoltage">Tension des cellules</string>
     <string name="button_HeatmapVoltage">Tension des cellules</string>
+    <string name="label_CellVoltageTop">Tension de cellule la plus haute (V)</string>
+    <string name="label_CellVoltageBottom">Tension de cellule la plus basse (V)</string>
+    <string name="label_CellVoltageDelta">Différence des tensions (mV)</string>
     <string name="title_activity_leakCurrents">Courant de fuite harmoniques</string>
     <string name="button_LeakCurrents">Harmoniques</string>
     <string name="label_LeakCurrentDc">Courant de fuite DC (mA)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -319,6 +319,9 @@
     <string name="title_activity_range">Пробег</string>
     <string name="title_activity_heatmap_bat">Карта температур</string>
     <string name="title_activity_heatmap_cellvoltage">Карта напряжений</string>
+    <string name="label_CellVoltageTop">Наивысшее напряжение ячейки (В)</string>
+    <string name="label_CellVoltageBottom">Наинизшее напряжение ячейки (В)</string>
+    <string name="label_CellVoltageDelta">Разница напряжений ячейки (мВ)</string>
     <string name="title_activity_firmware">Прошивка</string>
     <string name="title_activity_elm_test">Тест адаптора ELM327</string>
     <string name="title_activity_dtc">Коды ошибок (DTC)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -318,6 +318,9 @@
     <string name="title_activity_range">Пробіг</string>
     <string name="title_activity_heatmap_bat">Мапа температур</string>
     <string name="title_activity_heatmap_cellvoltage">Мапа напруг</string>
+    <string name="label_CellVoltageTop">Найвища напруга комірки (В)</string>
+    <string name="label_CellVoltageBottom">Найнижча напруга комірки (В)</string>
+    <string name="label_CellVoltageDelta">Різниця напруг комірки (мВ)</string>
     <string name="title_activity_firmware">Прошивка</string>
     <string name="title_activity_elm_test">Тест адаптору ELM327</string>
     <string name="title_activity_dtc">Коди помилок (DTC)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -728,6 +728,9 @@
     <string name="_73" translatable="false">73</string>
     <string name="_81" translatable="false">81</string>
     <string name="_89" translatable="false">89</string>
+    <string name="label_CellVoltageTop">Highest cell voltage (V)</string>
+    <string name="label_CellVoltageBottom">Lowest cell voltage (V)</string>
+    <string name="label_CellVoltageDelta">Cell voltage difference (mV)</string>
 
     <!-- LeakCurrents -->
 


### PR DESCRIPTION
Feature PR born out of paranoia which I may keep as a patch if you don't think it's necessary, but maybe someone finds it useful?

One of my cells started behaving so I wanted to watch it under different conditions. It is however a pain to keep track of the voltages visually as they jump around. There's no easy way to tell the voltage difference between the top and the bottom unless you have serious outliers. And without that you can't readily tell if your pack is getting balanced back together or otherwise. Hence this.

I added Ukrainian and Russian translations for the feature as well as my best guesses for German and French, which I think will need to be proofread. I kept the "Zellen-Spannung" thing with a dash and capitalization because it's how it's written otherwise on that screen.

Not sure if 3 line isn't too much, I tried making it one with slashes, but it's hard to make a non-confusing description that way.
Also not a Java coder so unsure if that `tv = (..); if (tv != null) {` pattern is really necessary in that case.

![image](https://user-images.githubusercontent.com/2434329/103182836-2b716980-48b7-11eb-9761-7e68fb924a3f.png)
